### PR TITLE
OED-3: Adding AutoSuggest to Form component

### DIFF
--- a/src/app/components/Form/Form.component.jsx
+++ b/src/app/components/Form/Form.component.jsx
@@ -9,6 +9,7 @@ import { Container } from "./Form.elements";
 
 // Import: Components
 import {
+  AutoSuggest,
   Button,
   Checkbox,
   Dropdown,
@@ -30,6 +31,11 @@ const FormGroupContext = createContext();
 
 //   return context;
 // };
+
+// Compound Component: FormAutoSuggest
+function FormAutoSuggest({ labelText }) {
+  return <AutoSuggest labelText={labelText} />;
+}
 
 // Compound Component: FormButton
 function FormButton({ onClick, text, type }) {
@@ -160,8 +166,8 @@ export default function Form(props) {
   );
 }
 
-// Export: Column
-// Form.Column = Column;
+// Export: AutoSuggest, Button, Checkbox, Dropdown, Input, Radio, Text, TextArea
+Form.AutoSuggest = FormAutoSuggest;
 Form.Button = FormButton;
 Form.Checkbox = FormCheckbox;
 Form.Dropdown = FormDropdown;

--- a/src/app/pages/EDOverview/EDOverview.component.jsx
+++ b/src/app/pages/EDOverview/EDOverview.component.jsx
@@ -40,7 +40,7 @@ export default function EDOverview() {
                       <Grid>
                         <Grid.Column>
                           <Grid.Item>
-                            <AutoSuggest labelText="Component: AutoSuggest" />
+                            <Form.AutoSuggest labelText="Component: AutoSuggest" />
                           </Grid.Item>
 
                           <Grid.Item>


### PR DESCRIPTION
Added `AutoSuggest` component to `Form` component as a compound component. Currently `AutoSuggest` only accepts the `labelText` prop, but will need further props adding in the future such as data sets.
[FORM: Assign AutoSuggest to compound components](https://app.gitkraken.com/glo/card/84e69503b34a4806845d1170f0408cb3)