### PR TITLE
OED-26-Anchor component created

### DIFF
--- a/src/app/components/Anchor/Anchor.component.jsx
+++ b/src/app/components/Anchor/Anchor.component.jsx
@@ -1,0 +1,24 @@
+// Import: Dependencies
+import React from "react";
+
+//Import:Elements
+import { StyledText } from "./Anchor.elements";
+
+// Component: Anchor
+export default function Anchor({ href, heading, subheading, text, ...props }) {
+  return (
+    <>
+      <StyledText
+        href={href}
+        target="_blank"
+        heading={heading}
+        subheading={subheading}
+        text={text}
+        {...props}
+        data-testid={"anchor"}
+      >
+        {props.children}
+      </StyledText>
+    </>
+  );
+}

--- a/src/app/components/Anchor/Anchor.elements.js
+++ b/src/app/components/Anchor/Anchor.elements.js
@@ -1,0 +1,69 @@
+// Import: Dependencies
+import styled, { css } from "styled-components/macro";
+
+// Element: StyledText
+export const StyledText = styled.a`
+  color: ${(props) => props.color ?? "#008ba3"};
+  margin: ${(props) => props.margin ?? 0};
+  padding: ${(props) => props.padding ?? 0};
+  ${({ heading, subheading, text }) => {
+    switch (true) {
+      case heading:
+        return css`
+          color: #008ba3;
+          font-size: 1.5em;
+          font-weight: 700;
+          text-decoration: underline;
+          transition: all 100ms linear;
+
+          &:hover {
+            color: #00687a;
+            transition: all 100ms linear;
+          }
+        `;
+      case subheading:
+        return css`
+          color: #008ba3;
+          font-size: 18px;
+          font-weight: 600;
+          text-decoration: underline;
+          transition: all 100ms linear;
+
+          &:hover {
+            color: #00687a;
+            transition: all 100ms linear;
+          }
+        `;
+      case text:
+        return css`
+          color: #008ba3;
+          font-size: 1rem;
+          font-weight: 400;
+          text-decoration: underline;
+          transition: all 100ms linear;
+
+          &:hover {
+            color: #00687a;
+            transition: all 100ms linear;
+          }
+        `;
+      default:
+        return css`
+          color: #008ba3;
+          font-size: 1rem;
+          font-weight: 400;
+          text-decoration: underline;
+          transition: all 100ms linear;
+
+          &:hover {
+            color: #00687a;
+            transition: all 100ms linear;
+          }
+        `;
+    }
+  }}
+`;
+
+// .topnav li:hover {
+//   border-bottom: 4px solid white;
+// }

--- a/src/app/components/Anchor/Anchor.test.js
+++ b/src/app/components/Anchor/Anchor.test.js
@@ -1,0 +1,17 @@
+// Import: Packages
+import { render } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+// Import: Component
+import Anchor from "./Anchor.component";
+
+// Test: Checks that Anchor renders
+it("checkAnchorRender", () => {
+  const { queryByTestId } = render(
+    <Router>
+      <Anchor />
+    </Router>
+  );
+  const component = queryByTestId("anchor");
+  expect(component).toBeTruthy();
+});

--- a/src/app/components/Form/Form.component.jsx
+++ b/src/app/components/Form/Form.component.jsx
@@ -9,6 +9,7 @@ import { Container, StyledForm } from "./Form.elements";
 
 // Import: Components
 import {
+  Anchor,
   AutoSuggest,
   Button,
   Checkbox,
@@ -31,6 +32,21 @@ const FormGroupContext = createContext();
 
 //   return context;
 // };
+
+// Compound Component: Anchor
+function FormAnchor({ href, heading, subheading, text, ...props }) {
+  return (
+    <Anchor
+      href={href}
+      heading={heading}
+      subheading={subheading}
+      text={text}
+      {...props}
+    >
+      {props.children}
+    </Anchor>
+  );
+}
 
 // Compound Component: FormAutoSuggest
 function FormAutoSuggest({ labelText }) {
@@ -174,7 +190,8 @@ export default function Form(props) {
   );
 }
 
-// Export: AutoSuggest, Button, Checkbox, Dropdown, Input, Radio, Text, TextArea
+// Export: Anchor, AutoSuggest, Button, Checkbox, Dropdown, Input, Radio, Text, TextArea
+Form.Anchor = FormAnchor;
 Form.AutoSuggest = FormAutoSuggest;
 Form.Button = FormButton;
 Form.Checkbox = FormCheckbox;

--- a/src/app/components/index.js
+++ b/src/app/components/index.js
@@ -1,3 +1,6 @@
+// Export: Anchor
+export { default as Anchor } from "./Anchor/Anchor.component"
+
 // Export: AutoSuggest
 export { default as AutoSuggest } from "./AutoSuggest/AutoSuggest.component";
 

--- a/src/app/pages/EDOverview/EDOverview.component.jsx
+++ b/src/app/pages/EDOverview/EDOverview.component.jsx
@@ -48,6 +48,12 @@ export default function EDOverview() {
                       <Grid.Item>
                         <Form.Dropdown labelText="Component: Dropdown" />
                       </Grid.Item>
+
+                      <Grid.Item>
+                        <Form.Anchor href="https://www.bing.com">
+                          Link to Bing
+                        </Form.Anchor>
+                      </Grid.Item>
                     </Grid.Column>
 
                     <Grid.Column>


### PR DESCRIPTION
OED-26-Anchor component created. 
Details: 

Create an Anchor component (.styles.js, .component.jsx, and .test.js)

Import Anchor in Form and allow Anchor to be a compound component (Form.Anchor)

Ensure that Anchor can accept all props normally passed to <a/> such as href

Set on hover colour change in the anchor.elements.js file. (On hover color = #00687A, normal colour = #008ba3

Added example of Form.Anchor to ED Overview page

[Anchor: Create an Anchor component](https://app.gitkraken.com/glo/card/25d41d91504a42d0a264905944cb287e)