### PR TITLE
OED-25: Amended Text component to accept bold prop

### DIFF
--- a/src/app/components/Form/Form.component.jsx
+++ b/src/app/components/Form/Form.component.jsx
@@ -124,10 +124,10 @@ function FormRadio({ checked, name, onChange, text, value }) {
 }
 
 // Compound Component: FormText
-function FormText({ as, heading, subheading, text, ...props }) {
+function FormText({ bold, heading, subheading, text, ...props }) {
   return (
     <Text
-      as={as}
+      bold={bold}
       heading={heading}
       subheading={subheading}
       text={text}

--- a/src/app/components/Text/Text.component.jsx
+++ b/src/app/components/Text/Text.component.jsx
@@ -5,11 +5,12 @@ import React from "react";
 import { StyledText } from "./Text.elements";
 
 // Component: Text
-export default function Text({ heading, subheading, text, ...props }) {
+export default function Text({ bold, heading, subheading, text, ...props }) {
   return (
     <>
       <StyledText
         as={props.as}
+        bold={bold}
         heading={heading}
         subheading={subheading}
         text={text}

--- a/src/app/components/Text/Text.elements.js
+++ b/src/app/components/Text/Text.elements.js
@@ -6,7 +6,7 @@ export const StyledText = styled.span`
   color: ${(props) => props.color ?? "#6b7a99;"};
   margin: ${(props) => props.margin ?? 0};
   padding: ${(props) => props.padding ?? 0};
-  ${({ heading, subheading, text }) => {
+  ${({ bold, heading, subheading, text }) => {
     switch (true) {
       case heading:
         return css`
@@ -25,6 +25,12 @@ export const StyledText = styled.span`
           color: #6b7a99;
           font-size: 1rem;
           font-weight: 400;
+        `;
+      case bold:
+        return css`
+          color: #6b7a99;
+          font-size: 1rem;
+          font-weight: 600;
         `;
       default:
         return css`

--- a/src/app/pages/EDOverview/EDOverview.component.jsx
+++ b/src/app/pages/EDOverview/EDOverview.component.jsx
@@ -117,6 +117,12 @@ export default function EDOverview() {
                           Component: Text (Text)
                         </Form.Text>
                       </Grid.Item>
+
+                      <Grid.Item>
+                        <Form.Text as="p" bold>
+                          Component: Text (Bold)
+                        </Form.Text>
+                      </Grid.Item>
                     </Grid.Column>
                   </Grid>
                 </Form>


### PR DESCRIPTION
Adjust the `Text` component so that it can receive `bold` as a boolean prop used to impact styling.

- Allow `Text` to accept `bold` as a prop
- Use the `bold` prop to determine styling
- Ensure `FormText`/`Text` can accept `bold` prop
[Text: Add bold condition](https://app.gitkraken.com/glo/card/1fcaece3354245ac95781585ca1973f4)