### PR TITLE
Overview Findings Fix, and Comments Cleanup

### DIFF
--- a/src/app/components/PatientDemographics/PatientDemographics.elements.js
+++ b/src/app/components/PatientDemographics/PatientDemographics.elements.js
@@ -228,6 +228,7 @@ export const TestGridWrapper = styled.div`
   width: 100%;
 `;
 
+// Element: Wrapper Item1
 export const WrapperItem1 = styled.div`
   flex: 2;
 
@@ -239,6 +240,8 @@ export const WrapperItem1 = styled.div`
     display: none;
   } ;
 `;
+
+// Element: Wrapper Item2
 export const WrapperItem2 = styled.div`
   flex: 5;
 
@@ -247,6 +250,7 @@ export const WrapperItem2 = styled.div`
   } ;
 `;
 
+// Element: OverFlowWrapper
 export const OverFlowWrapper = styled.div`
   height: 100%;
   max-height: 100%;

--- a/src/app/components/PatientDetails/PatientDetails.elements.js
+++ b/src/app/components/PatientDetails/PatientDetails.elements.js
@@ -86,6 +86,7 @@ export const ModalTopWrapper = styled.div`
 // Element: Modal Button Wrapper
 export const ModalButtonWrapper = styled.div``;
 
+// Element: Align Data
 export const AlignData = styled.div`
   align-items: top;
   display: flex;
@@ -96,12 +97,15 @@ export const AlignData = styled.div`
   width: 100%;
 `;
 
+// Element: Align Data 1
 export const AlignData1 = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   padding-right: 0.3rem;
 `;
+
+// Element:Align Data 2
 export const AlignData2 = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/app/pages/Overview/Overview.elements.js
+++ b/src/app/pages/Overview/Overview.elements.js
@@ -3,7 +3,6 @@ import styled from "styled-components/macro";
 
 // Element: Container
 export const Container = styled.div`
-  /* background-color: #f7f8fa; */
   grid-area: content;
   height: 100%;
   max-height: calc(100vh - 80px);
@@ -20,7 +19,6 @@ export const Wrapper = styled.div`
   flex-direction: column;
   height: 100%;
   justify-content: flex-start;
-  /* padding: 2rem; */
   width: 100%;
 `;
 

--- a/src/app/pages/Overview/subPages/Findings/Findings.component.jsx
+++ b/src/app/pages/Overview/subPages/Findings/Findings.component.jsx
@@ -89,7 +89,9 @@ export default function Findings() {
                               : "N/A"}
                           </Display>
                         </Grid.Item>
+                      </Grid.Column>
 
+                      <Grid.Column>
                         <Grid.Item>
                           <Display
                             htmlFor="onsetDateTime"


### PR DESCRIPTION
Overview Findings Fix, and Comments Cleanup:
-Changed the Findings component in the Overview section so that the data is rendered in 3 columns instead of 2
-Added comments to some elements files to show what the exported components are